### PR TITLE
[all-permissions] Request sysex for MIDI.

### DIFF
--- a/all-permissions.html
+++ b/all-permissions.html
@@ -110,7 +110,9 @@ var register = {
     );
   },
   "midi": function() {
-    navigator.requestMIDIAccess().then(
+    navigator.requestMIDIAccess({
+      sysex: true
+    }).then(
       displayOutcome("midi", "success"),
       displayOutcome("midi", "error")
     );


### PR DESCRIPTION
This triggers an explicit permission infobar for MIDI in Chrome.
(Without the sysex parameter, Chrome currently gives an automatic grant, even for "ask by default".)
