### PR TITLE
Remove browser flag section.

### DIFF
--- a/demos/all-permissions.html
+++ b/demos/all-permissions.html
@@ -58,15 +58,6 @@
 <button id="copy">Copy</button>
 <button id="download">Auto Download</button>
 
-
-<br><br><br>
-You may need to enable browser flags to test some permissions:<br>
-<table>
-<tr><td>MIDI</td><td><code>chrome://flags/#enable-web-midi</code></td></tr>
-<tr><td>Notifications (on Android)</td><td><code>chrome://flags/#enable-experimental-web-platform-features</code></td></tr>
-</table>
-
-
 <!--
   TODO:
   - Information about clearing settings in Chrome (can't link to chrome:// URLs)


### PR DESCRIPTION
All relevant APIs are unprefixed in Chrome (desktop and mobile) now.