### PR TITLE
[all-permissions] Add button to trigger USB device prompt in Chrome.

### DIFF
--- a/demos/all-permissions.html
+++ b/demos/all-permissions.html
@@ -47,6 +47,7 @@
 <button id="video">Video</button>
 <button id="audio+video">Audio + Video</button>
 <button id="midi">MIDI</button>
+<button id="usb">USB</button>
 <button id="eme">Encrypted Media (EME)</button>
 
 <hr>
@@ -182,6 +183,12 @@ var register = {
     }).then(
       displayOutcome("midi", "success"),
       displayOutcome("midi", "error")
+    );
+  },
+  "usb": function() {
+    navigator.usb.requestDevice({filters: [{}]}).then(
+      displayOutcome("usb", "success"),
+      displayOutcome("usb", "error")
     );
   },
   "eme": function() {


### PR DESCRIPTION
I don't yet know if it's easy to simulate the UX of an actual device, though.

![screen shot 2016-01-15 at 15 20 30](https://cloud.githubusercontent.com/assets/248078/12367978/bb34fe1e-bb9b-11e5-8ded-5b01253d6616.png)
